### PR TITLE
Explicitly specify license in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevy-settings"
 version = "0.4.0"
 edition = "2021"
-license-file = "LICENSE.md"
+license = "MIT"
 description = "Use a simple struct as persistent settings between game launches. Usefull for e.g. storing the audio settings"
 repository = "https://github.com/tecbeast42/bevy-settings"
 readme = "README.md"


### PR DESCRIPTION
In the [docs for the Cargo manifest format](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields), the use of `license-file` is only recommended for non-standard licenses. For standard licenses such as MIT, it should be specified in the `license` field explicitly.

This change makes it easier for tools to correctly identify the license. For example, right now the license is identified as `non-standard` on both [crates.io](https://crates.io/crates/bevy-settings) and the [Bevy Assets page](https://bevyengine.org/assets/#persistence).